### PR TITLE
Drop the setuid wrapper

### DIFF
--- a/container-exception-logger.spec
+++ b/container-exception-logger.spec
@@ -35,7 +35,7 @@ mkdir -p %{buildroot}/%{_mandir}/man1
 cp man/container-exception-logger.1 %{buildroot}/%{_mandir}/man1/container-exception-logger.1
 
 %files
-%attr(6755, root, root) %{_bindir}/container-exception-logger
+%{_bindir}/container-exception-logger
 %{_mandir}/man1/container-exception-logger.1.*
 %license COPYING
 

--- a/src/container-exception-logger.c
+++ b/src/container-exception-logger.c
@@ -60,25 +60,8 @@ int main(int argc, char *argv[])
     FILE *f = fopen(INIT_PROC_STDERR_FD_PATH, "w");
     if (f == NULL)
     {
-        perror("Failed to open '"INIT_PROC_STDERR_FD_PATH"' as root");
-
-        /* Try to open the 'INIT_PROC_STDERR_FD_PATH' as normal user because of
-           https://github.com/minishift/minishift/issues/2058
-        */
-        if (seteuid(getuid()) == 0)
-        {
-            f = fopen(INIT_PROC_STDERR_FD_PATH, "w");
-            if (f == NULL)
-            {
-                perror("Failed to open '"INIT_PROC_STDERR_FD_PATH"' as user");
-                return 2;
-            }
-        }
-        else
-        {
-            perror("Failed to setuid");
-            return 3;
-        }
+        perror("Failed to open '"INIT_PROC_STDERR_FD_PATH"'");
+        return 2;
     }
 
     setvbuf (f, NULL, _IONBF, 0);
@@ -99,7 +82,7 @@ int main(int argc, char *argv[])
         {
             perror("Failed to write to '"INIT_PROC_STDERR_FD_PATH"'");
             fclose(f);
-            return 4;
+            return 3;
         }
     }
     fclose(f);


### PR DESCRIPTION
The /proc/1 is owned by the UID running the container process (1xxxxxxxxx) so there is no
need to use setuid for CEL to write to /proc/1/fd/2.

Reverts:
https://github.com/abrt/abrt/commit/578317a67c0f30469c28752ea2f40ae87a1a356c

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>